### PR TITLE
fix raw json support: change hash keys symbol to string

### DIFF
--- a/lib/fluent/plugin/in_twitter.rb
+++ b/lib/fluent/plugin/in_twitter.rb
@@ -97,7 +97,7 @@ module Fluent
 
     def get_message(status)
       if @raw_json
-        record = status
+        record = status.inject({}){|f,(k,v)| f[k.to_s] = v; f}
       else
         record = Hash.new
         record.store('message', status.text)


### PR DESCRIPTION
y-ken様

昨日のraw json対応ですが、fluentdのエンジンに渡しているhashのキーがシンボルになっていたため、プラグイン間の連携で問題が起きてしまうことがわかりました。

mongodbに保存された段階では自動的にキーが文字列に変換されていたので気づくのがおくれました。
datacounterなど別のプラグインで、confで指定された文字列をキーとして参照している所でnilになってしまっていました。
hashのキーを文字列に変換して渡すように修正し、datacounterで正常にカウントできようにしました。

度々お手数掛けましてすみませんが、ご確認いただけますでしょうか。
よろしくお願いしますー。
