### PR TITLE
Support follow_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ gem install fluent-plugin-twitter
   oauth_token_secret  YOUR_OAUTH_TOKEN_SECRET # Required
   tag                 input.twitter.sampling  # Required
   timeline            sampling                # Required (sampling or userstream)
-  keyword             Ruby,Python             # Optional
+  keyword             Ruby,Python             # Optional (keyword is priority than follow_ids)
+  follow_ids          14252,53235             # Optional (integers, not screen names)
   lang                ja,en                   # Optional
   output_format       nest                    # Optional (nest or flat or simple[default])
 </source>

--- a/lib/fluent/plugin/in_twitter.rb
+++ b/lib/fluent/plugin/in_twitter.rb
@@ -11,6 +11,7 @@ module Fluent
     config_param :tag, :string
     config_param :timeline, :string
     config_param :keyword, :string, :default => nil
+    config_param :follow_ids, :string, :default => nil
     config_param :lang, :string, :default => nil
     config_param :output_format, :string, :default => 'simple'
     config_param :flatten_separator, :string, :default => '_'
@@ -57,12 +58,12 @@ module Fluent
       client = get_twitter_connection
       if @timeline == 'sampling' && @keyword
         client.track(@keyword)
-      elsif @timeline == 'sampling' && @keyword.nil?
+      elsif @timeline == 'sampling' && @follow_ids
+        client.follow(@follow_ids)
+      elsif @timeline == 'sampling' && @keyword.nil? && @follow_ids.nil?
         client.sample
       elsif @timeline == 'userstream'
         client.userstream
-      #elsif @timeline == 'follow'
-      #  client.follow(@follow_ids)
       end
     end
 
@@ -71,6 +72,7 @@ module Fluent
       notice << " tag:#{@tag}"
       notice << " lang:#{@lang}" unless @lang.nil?
       notice << " keyword:#{@keyword}" unless @keyword.nil?
+      notice << " follow:#{@follow_ids}" unless @follow_ids.nil? && !@keyword.nil?
       $log.info notice
       client = TweetStream::Client.new
       client.on_anything(&@any)


### PR DESCRIPTION
@y-ken さま

先ほどはありがとうございました。follow_idsに対応してみたのでレビューいただけると嬉しいです。
投げるのはstatuses/filterに違いないのでtimelime: followとせずsamplingとしてまとめてしまいました。

Twitter公式では"The track, follow, and locations fields should be considered to be combined with an OR operator. track=foo&follow=1234 returns Tweets matching “foo” OR created by user 1234."と書いていたのですが、tweetstreamの方のドキュメントでは"You can also use it to track keywords or follow a given set of user ids:"とどっちか選ぶようになっていてtrackとfollowを同時に投げる方法がパッと見見当たらなかった為どちらかしか投げないようになっています。

拙い実装で恐縮ですがご確認の程よろしくお願いいたします。
