### PR TITLE
require 'string/scrub' if RUBY_VERSION < '2.1'

### DIFF
--- a/fluent-plugin-twitter.gemspec
+++ b/fluent-plugin-twitter.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "fluentd", [">= 0.10.46"]
   s.add_runtime_dependency "twitter", ">= 5.0.0"
   s.add_runtime_dependency "tweetstream", [">= 2.6.1"]
-  s.add_runtime_dependency "string-scrub" if RUBY_VERSION < "2.1"
+  s.add_runtime_dependency "string-scrub" if RUBY_VERSION.to_f < 2.1
 end

--- a/lib/fluent/plugin/in_twitter.rb
+++ b/lib/fluent/plugin/in_twitter.rb
@@ -1,4 +1,4 @@
-require 'string/scrub' if RUBY_VERSION < '2.1'
+require 'string/scrub' if RUBY_VERSION.to_f < 2.1
 
 module Fluent
   class TwitterInput < Fluent::Input


### PR DESCRIPTION
`string-scrub` is specified in gemspec, but is not required in code.

So, I added `require` clause, and it works in my td-agent with ruby 1.9.3.
