### PR TITLE
Add missing license entry in gemspec

### DIFF
--- a/fluent-plugin-twitter.gemspec
+++ b/fluent-plugin-twitter.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.email       = ["y.ken.studio@gmail.com"]
   s.homepage    = "https://github.com/y-ken/fluent-plugin-twitter"
   s.summary     = %q{Fluentd Input/Output plugin to collect/process tweets with Twitter Streaming API.}
+  s.license     = "Apache-2.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Display license information on rubygems.org