### PR TITLE
Correct false positives in language determination.

### DIFF
--- a/lib/fluent/plugin/in_twitter.rb
+++ b/lib/fluent/plugin/in_twitter.rb
@@ -92,7 +92,7 @@ module Fluent::Plugin
 
     def is_message?(tweet)
       return false if !tweet.is_a?(Twitter::Tweet)
-      return false if (!@lang.nil? && @lang != '') && !@lang.include?(tweet.user.lang)
+      return false if (!@lang.nil? && @lang != '') && !@lang.include?(tweet.lang)
       if @timeline == :userstream && (!@keyword.nil? && @keyword != '')
         pattern = NKF::nkf('-WwZ1', @keyword).gsub(/,\s?/, '|')
         tweet = NKF::nkf('-WwZ1', tweet.text)


### PR DESCRIPTION
HI 
twitter.user.lang has become null due to a sudden specification change of twitter streaming api.

https://developer.twitter.com/en/docs/tweets/sample-realtime/api-reference

so,now.input parameter is not work.
```
 lang                ja,en                    # Optional
```
in_twitter.rb return allways true,even a language different from the specified language.
```
 return false if (!@lang.nil? && @lang != '') && !@lang.include?(tweet.user.lang)
```

so.therefore, I changed to use `twitter.lang` instead of `twitter.user.lang` to determine the language.